### PR TITLE
fix comment issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,11 @@ module.exports = function(filename) {
         return this.emit('error', 'error parsing ' + filename + ': ' + err);
       }
       tree.stylesheet.rules.forEach(function(rule) {
+        if (rule.type !== 'rule') return;
         rule.selectors.forEach(function(selector) {
           var styles = (modExports[selector] = modExports[selector] || {});
           rule.declarations.forEach(function(declaration) {
+            if (declaration.type !== 'declaration') return;
             styles[toCamelCase(declaration.property)] = declaration.value;
           });
         });


### PR DESCRIPTION
If you have comments at the top-level of the CSS file, then the rule.selectors loop will break. If you have it within a selector then the declarations loop will break. This fixes both.
